### PR TITLE
fix build & warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS = -g -O2 -Wall  $(shell libpng-config --cflags)
-LDFLAGS = $(shell libpng-config --ldflags)
+LDLIBS = $(shell libpng-config --ldflags)
 
 PROGRAMS = fb2png
 

--- a/fb2png.c
+++ b/fb2png.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #include <unistd.h>
 #include <linux/fb.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
This fix:
- building on Mageia where LDFLAGS is overriden (and LDLIBS is what must be used here anyway)
- some string warnings
